### PR TITLE
Update volume mounts for each workflow step

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -215,24 +215,18 @@ class KubernetesPodBuilder(object):
         # For workflow steps, only mount the aws user-service volume
         # And mount it to the shared credentials location
         if self.name not in ["node_stage_in", "node_stage_out"]:
-            count = 0
             for vol_m in self.volume_mounts[:]:
                 log.info(vol_m["name"])
                 log.info(vol_m["mountPath"])
                 if vol_m["name"].startswith("aws-credentials-service-"):
                     vol_m["mountPath"] = vol_m["mountPath"].replace("/service", "")
                     log.info("Updated mount path for workspace credentials")
-                    count += 1
-                if vol_m["name"].startswith("aws-credentials-workspace-"):
+                elif vol_m["name"].startswith("aws-credentials-workspace-"):
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed aws volume for calling workspace")
-                    count += 1
-                if vol_m["name"].startswith("temp-pvc-workspace-"):
+                elif vol_m["name"].startswith("temp-pvc-workspace-"):
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed volume for calling workspace")
-                    count += 1
-                if count == 3:
-                    break
         elif self.name == "node_stage_in":
             for vol_m in self.volume_mounts[:]:
                 log.info(vol_m["name"])
@@ -241,23 +235,17 @@ class KubernetesPodBuilder(object):
                     log.info("Removed volume for executing workspace")
                     break
         elif self.name == "node_stage_out":
-            count = 0
             for vol_m in self.volume_mounts[:]:
                 log.info(vol_m["name"])
                 if vol_m["name"].startswith("aws-credentials-workspace-"):
                     vol_m["mountPath"] = vol_m["mountPath"].replace("/workspace", "")
                     log.info("Updated mount path for user service credentials")
-                    count += 1
-                if vol_m["name"].startswith("aws-credentials-service-"):
+                elif vol_m["name"].startswith("aws-credentials-service-"):
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed aws volume for user service workspace")
-                    count += 1
-                if vol_m["name"] == "pvc-workspace":
+                elif vol_m["name"] == "pvc-workspace":
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed volume for executing workspace")
-                    count += 1
-                if count == 3:
-                    break
 
 
     def pod_name(self):


### PR DESCRIPTION
## Configure the volume mounts for each step of the workflow
- Ensure the correct aws-creds and workspace PVCs are mounted for each step of a workflow, including stage-in and stage-out
- Only the stagein and stageout can access the calling workspace data
- Only the workflow steps can access the executing workspace data