### PR TITLE
Check if user service before removing volume mounts

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -212,12 +212,20 @@ class KubernetesPodBuilder(object):
         self.security_context = security_context
         self.serviceaccount = serviceaccount
 
+        # Check if this is a user service
+        # TODO: implement better way to identify this using parameters
+        is_user_service = False
+        for vol_m in self.volume_mounts:
+            # "temp-pvc-workspace-" only mounted for user services
+            if vol_m["name"].startswith("temp-pvc-workspace-"):
+                log.info("Identified User Service")
+                is_user_service = True
+                break
+
         # For workflow steps, only mount the aws user-service volume
         # And mount it to the shared credentials location
         if self.name not in ["node_stage_in", "node_stage_out"]:
             for vol_m in self.volume_mounts[:]:
-                log.info(vol_m["name"])
-                log.info(vol_m["mountPath"])
                 if vol_m["name"].startswith("aws-credentials-service-"):
                     vol_m["mountPath"] = vol_m["mountPath"].replace("/service", "")
                     log.info("Updated mount path for workspace credentials")
@@ -228,22 +236,21 @@ class KubernetesPodBuilder(object):
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed volume for calling workspace")
         elif self.name == "node_stage_in":
-            for vol_m in self.volume_mounts[:]:
-                log.info(vol_m["name"])
-                if vol_m["name"] == "pvc-workspace":
-                    self.volume_mounts.remove(vol_m)
-                    log.info("Removed volume for executing workspace")
-                    break
+            if is_user_service:
+                for vol_m in self.volume_mounts[:]:
+                    if vol_m["name"] == "pvc-workspace":
+                        self.volume_mounts.remove(vol_m)
+                        log.info("Removed volume for executing workspace")
+                        break
         elif self.name == "node_stage_out":
             for vol_m in self.volume_mounts[:]:
-                log.info(vol_m["name"])
                 if vol_m["name"].startswith("aws-credentials-workspace-"):
                     vol_m["mountPath"] = vol_m["mountPath"].replace("/workspace", "")
                     log.info("Updated mount path for user service credentials")
                 elif vol_m["name"].startswith("aws-credentials-service-"):
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed aws volume for user service workspace")
-                elif vol_m["name"] == "pvc-workspace":
+                elif is_user_service and vol_m["name"] == "pvc-workspace":
                     self.volume_mounts.remove(vol_m)
                     log.info("Removed volume for executing workspace")
 


### PR DESCRIPTION
## Only remove pvc-workspace volume mount if the workflow is NOT a user-service
- Check for a temporary PVC specifying this workflows is being run as a user-service
- Only if this PVC is present can we remove the pvc-workspace volume from stage-in and stage-out steps