### PR TITLE
Update requests to be limits to ensure max usage

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -213,7 +213,7 @@ class KubernetesPodBuilder(object):
         is_user_service = False
         for vol_m in self.volume_mounts:
             # "temp-pvc-workspace-" only mounted for user services
-            if vol_m.name.startswith("temp-pvc-workspace-"):
+            if vol_m["name"].startswith("temp-pvc-workspace-"):
                 log.info("Identified User Service")
                 is_user_service = True
                 break
@@ -222,14 +222,14 @@ class KubernetesPodBuilder(object):
         if is_user_service:
             if self.name.startswith("node_stage_in") or self.name == "node_stage_out":
                 for vol_m in self.volume_mounts[:]:
-                    log.info(vol_m.name)
-                    if vol_m.name == "pvc-workspace":
+                    log.info(vol_m["name"])
+                    if vol_m["name"] == "pvc-workspace":
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for executing workspace")
                         break
             else:
                 for vol_m in self.volume_mounts[:]:
-                    if vol_m.name.startswith("temp-pvc-workspace-"):
+                    if vol_m["name"].startswith("temp-pvc-workspace-"):
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for calling workspace")
                         break

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -331,7 +331,7 @@ class KubernetesPodBuilder(object):
         log.debug('Building resources spec from {}'.format(self.resources))
         container_resources = {}
         for cwl_field, cwl_value in self.resources.items():
-            resource_bound = 'requests'
+            resource_bound = 'limits'
             resource_type = self.resource_type(cwl_field)
             resource_value = self.resource_value(resource_type, cwl_value)
             if resource_type and resource_value:

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -213,7 +213,7 @@ class KubernetesPodBuilder(object):
         is_user_service = False
         for vol_m in self.volume_mounts:
             # "temp-pvc-workspace-" only mounted for user services
-            if vol_m["name"].startswith("temp-pvc-workspace-"):
+            if vol_m.name.startswith("temp-pvc-workspace-"):
                 log.info("Identified User Service")
                 is_user_service = True
                 break
@@ -222,14 +222,14 @@ class KubernetesPodBuilder(object):
         if is_user_service:
             if self.name.startswith("node_stage_in") or self.name == "node_stage_out":
                 for vol_m in self.volume_mounts[:]:
-                    log.info(vol_m["name"])
-                    if vol_m["name"] == "pvc-workspace":
+                    log.info(vol_m.name)
+                    if vol_m.name == "pvc-workspace":
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for executing workspace")
                         break
             else:
                 for vol_m in self.volume_mounts[:]:
-                    if vol_m["name"].startswith("temp-pvc-workspace-"):
+                    if vol_m.name.startswith("temp-pvc-workspace-"):
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for calling workspace")
                         break

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -352,6 +352,7 @@ class KubernetesPodBuilder(object):
         Submitted node selectors must be strings
         :return:
         """
+        log.info(f"Node selectors: {self.nodeselectors}")
         return {str(k): str(v) for k, v in self.nodeselectors.items()}
     
     def pod_tolerations(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -371,7 +371,7 @@ class KubernetesPodBuilderTestCase(TestCase):
         self.pod_builder.resources = {'cores': 2, 'ram': 256}
         resources = self.pod_builder.container_resources()
         expected = {
-            'requests': {
+            'limits': {
                 'cpu': '2',
                 'memory': '256Mi'
             }
@@ -449,7 +449,7 @@ class KubernetesPodBuilderTestCase(TestCase):
                             {'name': 'K2', 'value': 'V2'},
                         ],
                         'resources': {
-                            'requests': {
+                            'limits': {
                                 'cpu': '1',
                                 'memory': '1024Mi',
                             }

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -86,10 +86,12 @@ class KubernetesPodVolumeInspectorTestCase(TestCase):
     def test_get_mounted_persistent_volumes(self):
         mock_pod = Mock()
         mock_volume_mount1 = Mock()
+        mock_volume_mount1.get.return_value = "data1"
         mock_volume_mount1.name = 'data1'
         mock_volume_mount1.mount_path = '/data/one'
         mock_volume_mount1.sub_path = None
         mock_volume_mount2 = Mock()
+        mock_volume_mount2.get.return_value = "data2"
         mock_volume_mount2.name = 'data2'
         mock_volume_mount2.mount_path = '/data/two'
         mock_volume_mount2.sub_path = '/basedir'
@@ -109,10 +111,12 @@ class KubernetesPodVolumeInspectorTestCase(TestCase):
     def test_get_mounted_persistent_volumes_ignores_unmounted_volumes(self):
         mock_pod = Mock()
         mock_volume_mount1 = Mock()
+        mock_volume_mount1.get.return_value = "data1"
         mock_volume_mount1.name = 'data1'
         mock_volume_mount1.mount_path = '/data/one'
         mock_volume_mount1.sub_path = None
         mock_volume_mount2 = Mock()
+        mock_volume_mount2.get.return_value = "data2"
         mock_volume_mount2.name = 'data2'
         mock_volume_mount2.mount_path = '/data/two'
         mock_volume_mount2.sub_path = 'basedir'


### PR DESCRIPTION
## Set `limits` for pods rather than `requests`
- Should ensure pods use **at most** the specified requirements
- We can then introduce a maximum allowance, either at the point of workflow deployment, or elsewhere in the code to restrict these limits to a maximum mount of RAM and CPU