### PR TITLE
Remove `workspace` from volume name to align with latest pvc naming c…

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -213,7 +213,7 @@ class KubernetesPodBuilder(object):
         is_user_service = False
         for vol_m in self.volume_mounts:
             # "temp-pvc-workspace-" only mounted for user services
-            if vol_m["name"].startswith("temp-pvc-workspace-"):
+            if vol_m["name"].startswith("temp-pvc-"):
                 log.info("Identified User Service")
                 is_user_service = True
                 break
@@ -223,13 +223,13 @@ class KubernetesPodBuilder(object):
             if self.name.startswith("node_stage_in") or self.name == "node_stage_out":
                 for vol_m in self.volume_mounts[:]:
                     log.info(vol_m["name"])
-                    if vol_m["name"] == "pvc-workspace":
+                    if vol_m["name"].startswith("pvc-"):
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for executing workspace")
                         break
             else:
                 for vol_m in self.volume_mounts[:]:
-                    if vol_m["name"].startswith("temp-pvc-workspace-"):
+                    if vol_m["name"].startswith("temp-pvc-"):
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for calling workspace")
                         break


### PR DESCRIPTION
## Update for new PVC names
- Workspace PVCs are now called `pvc-<workspace-name>` rather than `pvc-workspace` so we need to update the code to check for names matching the new format, rather than previous format