### PR TITLE
mount workspace tokens automatically, also add linkerd annotations fo…

### DIFF
--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -238,9 +238,27 @@ class KubernetesPodBuilder(object):
         # Check if this is a user service
         is_user_service = self.executing_workspace != self.calling_workspace
 
+        # Set stageout indicator
+        self.is_stageout = self.name.startswith("node_stage_out")
+
+        # Get workspace access tokens from params
+        with open("/workflow-params/params.yml", "r") as f:
+            params = yaml.safe_load(f)
+            token = params.get("WORKSPACE_ACCESS_TOKEN", None)
+            calling_token = params.get("CALLING_WORKSPACE_ACCESS_TOKEN", None)
+
+        # Set workspace token if requested
+        if "WORKSPACE_TOKEN" in self.environment and self.environment["WORKSPACE_TOKEN"] == "<<REPLACE>>":
+            self.environment["WORKSPACE_TOKEN"] = token
+
+        # Set calling workspace token if requested and stagein step
+        if self.name.startswith("node_stage_in"):
+            if "WORKSPACE_ACCESS_TOKEN" in self.environment and self.environment["WORKSPACE_ACCESS_TOKEN"] == "<<REPLACE>>":
+                self.environment["WORKSPACE_ACCESS_TOKEN"] = calling_token
+
         # For user services we need to remove PVCs depending on calling or executing workspaces
         if is_user_service:
-            if self.name.startswith("node_stage_in") or self.name == "node_stage_out":
+            if self.name.startswith("node_stage_in") or self.name.startswith("node_stage_out"):
                 for vol_m in self.volume_mounts[:]:
                     if vol_m["name"].startswith("pvc-"):
                         self.volume_mounts.remove(vol_m)
@@ -248,12 +266,19 @@ class KubernetesPodBuilder(object):
                         break
                 # Also update service account to be calling account
                 self.serviceaccount = self.calling_service_account
+                # And remove workspace token for executing workspace
+                if "WORKSPACE_TOKEN" in self.environment:
+                    del self.environment["WORKSPACE_TOKEN"]
             else:
                 for vol_m in self.volume_mounts[:]:
                     if vol_m["name"].startswith("temp-pvc-"):
                         self.volume_mounts.remove(vol_m)
                         log.info("Removed volume for calling workspace")
                         break
+
+        if self.name.startswith("node_stage_out"):
+            # Record that this is the stageout pod for use when adding annotations
+            self.is_stageout = True
 
 
     def pod_name(self):
@@ -422,6 +447,12 @@ class KubernetesPodBuilder(object):
         
         if ( self.serviceaccount ):
             spec['spec']['serviceAccountName'] = self.serviceaccount
+
+        if ( self.is_stageout ):
+            # Add annotations for stageout
+            spec['metadata']['annotations'] = {
+                "linkerd.io/inject": "enabled",
+            }
         
         return spec
 

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -444,7 +444,7 @@ class KubernetesPodBuilder(object):
             spec['spec']['serviceAccountName'] = self.serviceaccount
 
         if ( self.is_stageout ):
-            # Add annotations for stageout
+            # Add annotations for linkerd to stageout
             spec['metadata']['annotations'] = {
                 "linkerd.io/inject": "enabled",
             }

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -276,11 +276,6 @@ class KubernetesPodBuilder(object):
                         log.info("Removed volume for calling workspace")
                         break
 
-        if self.name.startswith("node_stage_out"):
-            # Record that this is the stageout pod for use when adding annotations
-            self.is_stageout = True
-
-
     def pod_name(self):
         tag = random_tag()
         return k8s_safe_name('{}-pod-{}'.format(self.name, tag))

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -122,7 +122,11 @@ class KubernetesVolumeBuilder(object):
             # Mount any additional volumes not already mounted, only duplicate is "calrissian-wdir"
             if claim_name != "calrissian-wdir":
                 log.info(f"Adding PVC {claim_name} mounted at {mount_path}")
-                self.add_volume_binding(mount_path, mount_path, False)
+                writable = False
+                # Need to allow writing to the workspace directory
+                if claim_name.startswith("pvc-"):
+                    writable = True
+                self.add_volume_binding(mount_path, mount_path, writable=writable)
 
     def add_persistent_volume_entry(self, prefix, sub_path, claim_name, read_only):
         entry = {

--- a/calrissian/job.py
+++ b/calrissian/job.py
@@ -122,10 +122,8 @@ class KubernetesVolumeBuilder(object):
             # Mount any additional volumes not already mounted, only duplicate is "calrissian-wdir"
             if claim_name != "calrissian-wdir":
                 log.info(f"Adding PVC {claim_name} mounted at {mount_path}")
-                writable = False
                 # Need to allow writing to the workspace directory
-                if claim_name.startswith("pvc-"):
-                    writable = True
+                writable = claim_name.startswith("pvc-")
                 self.add_volume_binding(mount_path, mount_path, writable=writable)
 
     def add_persistent_volume_entry(self, prefix, sub_path, claim_name, read_only):

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import os
 import shlex
+import yaml
 
 log = logging.getLogger("calrissian.main")
 
@@ -108,16 +109,22 @@ def flush_tees():
     sys.stdout.flush()
     sys.stderr.flush()
 
-def check_for_illegal_steps(cwl_dict: dict):
+def check_for_illegal_steps(cwl_location: str):
     """
     Checks for illegal steps in the CWL workflow.
     """
-    for item in cwl_dict["$graph"]:
-        if item.get("id", "main") != "main":
-            steps = item.get("steps", [])
-            for step in steps:
-                if step["id"].startswith("node_stage_in") or step["id"].startswith("node_stage_out"):
-                    raise WorkflowException(f"Illegal step included in workflow: {step["id"]}")
+    log.info(f"Checking for illegal steps in workflow: {cwl_location}")
+    cwl_location = cwl_location.rsplit(".cwl#", 1)[0]
+    if not cwl_location.endswith(".cwl"):
+        cwl_location = cwl_location + ".cwl"
+    with open(cwl_location, 'r') as cwl_file:
+        cwl_dict = yaml.safe_load(cwl_file)
+    for workflow_item in cwl_dict["$graph"]:
+        if workflow_item["class"] == "Workflow" and workflow_item["id"] != "main":
+            item_steps = workflow_item.get("steps", {})
+            for step_id in list(item_steps.keys()):
+                if step_id.startswith("node_stage_in") or step_id.startswith("node_stage_out"):
+                    raise WorkflowException(f"Illegal step included in workflow: {step_id}")
 
 def main():
     parser = arg_parser()
@@ -133,6 +140,7 @@ def main():
     runtime_context = CalrissianRuntimeContext(vars(parsed_args))
     runtime_context.select_resources = executor.select_resources
     install_signal_handler()
+    check_for_illegal_steps(parsed_args.workflow)
     try:
         result = cwlmain(args=parsed_args,
                          executor=executor,

--- a/calrissian/main.py
+++ b/calrissian/main.py
@@ -4,6 +4,7 @@ from calrissian.version import version
 from calrissian.k8s import delete_pods
 from calrissian.report import initialize_reporter, write_report, CPUParser, MemoryParser
 from cwltool.main import main as cwlmain
+from cwltool.errors import WorkflowException
 from cwltool.argparser import arg_parser
 from typing_extensions import Text
 import logging
@@ -107,6 +108,16 @@ def flush_tees():
     sys.stdout.flush()
     sys.stderr.flush()
 
+def check_for_illegal_steps(cwl_dict: dict):
+    """
+    Checks for illegal steps in the CWL workflow.
+    """
+    for item in cwl_dict["$graph"]:
+        if item.get("id", "main") != "main":
+            steps = item.get("steps", [])
+            for step in steps:
+                if step["id"].startswith("node_stage_in") or step["id"].startswith("node_stage_out"):
+                    raise WorkflowException(f"Illegal step included in workflow: {step["id"]}")
 
 def main():
     parser = arg_parser()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='dan.leehr@duke.edu',
     description='CWL runner for Kubernetes',
     install_requires=[
-        'urllib3>=2.5.0',
+        'urllib3>=1.24.2,<1.27',
         'kubernetes==10.0.1',
         'cwltool==3.1.20230201224320',
         'tenacity==5.1.1',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='dan.leehr@duke.edu',
     description='CWL runner for Kubernetes',
     install_requires=[
-        'urllib3>=1.24.2,<1.27',
+        'urllib3>=2.5.0',
         'kubernetes==10.0.1',
         'cwltool==3.1.20230201224320',
         'tenacity==5.1.1',


### PR DESCRIPTION
## Update Workspace Token Functionality
- Mount workspace tokens as environment variables where requested
- Only mount allowed tokens to either stagein/out or user workflow steps
- Add linkerd annotations to allow Pulsar messaging in stageout
- Add final check for illegal workflow steps: `node_stage_in` and `node_stage_out` to avoid incorrect permissions
- Setting workspace PVC for executing workspace to be read/write